### PR TITLE
feat: build for multiarch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,21 @@ parts:
     source: .
     python-requirements:
       - requirements.txt
+    python-packages:
+      # NOTE (mertkirpici): confluent-kafka versions are compatible with the same
+      # librdkafka versions. jammy repositories have librdkafka==1.8
+      # https://github.com/confluentinc/confluent-kafka-python/releases
+      - confluent-kafka==1.8.2
+    build-packages:
+      - libssl-dev
+      - libffi-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - libpq-dev
+      - librdkafka-dev
+      - rustc
+      - cargo
+      - pkg-config
     override-prime: |
       craftctl default
       craftctl set version="$(tempest --version | awk '{print $2}')"


### PR DESCRIPTION
This patch will enable support for the following architectures:
- amd64
- arm64
- armhf
- ppc64el
- s390x

Testing snap [recipe](https://launchpad.net/~mertkirpici/snap-tempest/+snap/tempest-test-arch)