### PR TITLE
Add license in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
  OpenStack cluster. Tempest has batteries of tests for OpenStack
  API validation, Scenarios, and other specific tests useful in
  validating an OpenStack deployment.
+license: Apache-2.0
 confinement: strict
 grade: stable
 base: core22


### PR DESCRIPTION
Add `license` field in snapcraft.yaml so that running `snap info tempest` after snap installation will show `Apache-2.0` instead of `unset`