### PR TITLE
feat: use tools from stable branches

### DIFF
--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -20,13 +20,7 @@ jobs:
       - name: Update Snapcraft Yaml
         id: update_snapcraft
         run: |
-          # use the script from the default branch so that the changes
-          # made to the script are not needed to be backported to stable
-          # branches
-          git fetch origin
-          git restore --source origin/${{ github.event.repository.default_branch }} tools/
           tox -e release -- -o snap/snapcraft.yaml -r ${{ inputs.openstack-release }}
-          git checkout -- tools/
           git diff --exit-code snap/snapcraft.yaml \
           && echo "create_pr=0" >> $GITHUB_OUTPUT \
           || echo "create_pr=1" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The old implementation used the update_snapcraft.py script from the default branch, however ussuri release needs to be built on a different core, which requires confluent-kafka version to be different, hence use the script committed to its stable branch.