### PR TITLE
Add bobcat support and update README

### DIFF
--- a/.github/workflows/update-tempest-releases.yaml
+++ b/.github/workflows/update-tempest-releases.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [antelope, zed, yoga, xena, wallaby, victoria, ussuri]
+        release: [bobcat, antelope, zed, yoga, xena, wallaby, victoria, ussuri]
     uses: ./.github/workflows/update-snapcraft.yaml
     with:
       openstack-release: ${{ matrix.release }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The tempest snap can be installed directly from the snap store:
 
     sudo snap install [install-OPTIONS] tempest
 
-By default, tempest snap will be installed from `latest/stable` channel unless a different
+By default, tempest snap will be installed from the stable channel of the latest OpenStack
+release, e.g. `2023.1/stable` if `antelope` is the most recent release, unless a different
 channel is explicitly specified. This channel is generally compatible with actively developed
 OpenStack releases thanks to the relatively flexible alignment between Tempest and its plugins
 with OpenStack versions. 


### PR DESCRIPTION
- Add dependency automation for `stable/bobcat` branch
- Update README since now we are setting the track of the latest supporting OpenStack release as the default