### PR TITLE
fix paths in .stestr.conf

### DIFF
--- a/snap/local/tempest-wrapper
+++ b/snap/local/tempest-wrapper
@@ -5,4 +5,13 @@ tests_dir=$TESTS
 final_args=$(echo $original_args | sed "s|@BUILTIN_TESTLISTS|$tests_dir|g")
 
 IFS=' ' read -a arr <<< "$final_args"
+
+# owerrite the paths (e.g. /snap/tempest/123 or /snap/tempest/x1) define in .stestr.conf with ${SNAP}
+# TODO: extract dir
+regex_string='s/\/snap\/tempest\/\([x,0-9]\+\)/${SNAP}/g'
+stestr_conf=".stestr.conf"
+if [[ -f "$stestr_conf" ]]; then
+    sed -i $regex_string $stestr_conf
+fi
+
 exec ${arr[@]}


### PR DESCRIPTION
Without this, the `.stestr.conf` will contain the full path to snap tempest, which will be changed after snap update.

fixes: #8