### PR TITLE
Process args for tempest to avoid resplitting

### DIFF
--- a/snap/local/tempest-wrapper
+++ b/snap/local/tempest-wrapper
@@ -1,8 +1,8 @@
 #!/bin/bash
-original_args="$*"
-tests_dir=$TESTS
 
-final_args=$(echo $original_args | sed "s|@BUILTIN_TESTLISTS|$tests_dir|g")
+args=()
+for arg in "$@"; do
+    args+=("$(printf "%s" "$arg" | sed "s|@BUILTIN_TESTLISTS|$TESTS|g")")
+done
 
-IFS=' ' read -a arr <<< "$final_args"
-exec ${arr[@]}
+exec "${args[@]}"


### PR DESCRIPTION
Previously, in tempest-wrapper,
arguments containing whitespace were split into multiple arguments, because of the type of processing.
Use different bash logic with arrays to retain the arguments as-is, while still performing the same argument replacing.

Fixes #62 