### PR TITLE
Add explanation for token replacement and suggest future actions

### DIFF
--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.update_snapcraft.outputs.create_pr == 1 }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git config user.name "Github Action Bot"
           git config user.email "<>"

--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.update_snapcraft.outputs.create_pr == 1 }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}  # update this token in repo secret when no longer valid 
         run: |
           git config user.name "Github Action Bot"
           git config user.email "<>"


### PR DESCRIPTION
Replacing the default repo token with a personal token, so that the normal workflows (lint, unit, functional checks) would get triggered in bot created PRs.

close-after: #71 