### PR TITLE
Allow manually bumping the Tempest version in snapcraft.yaml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,5 +68,6 @@ deps =
     pygit2
     pyyaml
     semver
+    packaging
 changedir = {toxinidir}
 commands = python3 tools/update_snapcraft.py {posargs}


### PR DESCRIPTION
update_snapcraft.py is used to automatically detect when there are available updates for component packaged in the snap (Tempest, tempestconf, Tempest plugins). Since the comparison is a simple diff, it is impossible to manually override versions in snapcraft.yaml because the automation would try to revert the changes. This commit prevents reverting to an older Tempest version, therefore allowing for manual version bumps (of Tempest only - the behavior remains unchanged for other components)

Partial: #76