### PR TITLE
Feat/update snapcraft from main

### DIFF
--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -20,7 +20,13 @@ jobs:
       - name: Update Snapcraft Yaml
         id: update_snapcraft
         run: |
+          # use the script from the default branch so that the changes
+          # made to the script are not needed to be backported to stable
+          # branches
+          git fetch origin
+          git restore --source origin/${{ github.event.repository.default_branch }} tools/
           tox -e release -- -o snap/snapcraft.yaml -r ${{ inputs.openstack-release }}
+          git checkout -- tools/
           git diff --exit-code snap/snapcraft.yaml \
           && echo "create_pr=0" >> $GITHUB_OUTPUT \
           || echo "create_pr=1" >> $GITHUB_OUTPUT

--- a/requirements-manual.txt
+++ b/requirements-manual.txt
@@ -1,0 +1,3 @@
+# this is needed by the monasca plugin
+# see https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
+confluent-kafka==1.8.2

--- a/tools/update_snapcraft.py
+++ b/tools/update_snapcraft.py
@@ -19,6 +19,7 @@ import pygit2
 import semver
 import yaml
 from packaging import version
+from packaging.requirements import InvalidRequirement, Requirement
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,28 @@ OPENDEV_BASE_URL = "git+https://opendev.org"
 OPENSTACK_REPO_URL_FMT = OPENDEV_BASE_URL + "/openstack/{project}.git@{ref}"
 OPENINFRA_REPO_URL_FMT = OPENDEV_BASE_URL + "/openinfra/{project}.git@{ref}"
 PYPI_RSS_FEED_FMT = "https://pypi.org/rss/project/{project}/releases.xml"
-ADDITIONAL_REQUIREMENTS = ["confluent-kafka==1.8.2"]
+MANUAL_REQUIREMENTS = Path(__file__).parents[1] / Path("requirements-manual.txt")
+
+
+def parse_manual_requirements(path):
+    """Parse a requirements.txt path.
+
+    Ingests a path and returns a set of requirement strings.
+    Comments are stripped, and invalid requirements are skipped.
+    """
+    manual_requirements = set()
+
+    if path.exists():
+        with open(path, encoding="utf-8") as req_file:
+            for line in req_file:
+                try:
+                    # Requirement cannot handle comments
+                    req = Requirement(line.split("#", maxsplit=1)[0])
+                    manual_requirements.add(str(req))
+                except InvalidRequirement:
+                    pass
+
+    return manual_requirements
 
 
 def parse_args():
@@ -130,7 +152,7 @@ def main(args):
 
     # Update plugin versions unconditionally
     snapcraft_yaml["parts"]["tempest"]["python-packages"] = [
-        *ADDITIONAL_REQUIREMENTS,
+        *parse_manual_requirements(MANUAL_REQUIREMENTS),
         *get_latest_plugin_requirements(args.release),
         get_latest_tempestconf_requirements(),
     ]


### PR DESCRIPTION
This commit makes it possible for the automation workflow to always run update_snapcraft.py from the main branch, as the branch-specific requirements that cannot be dynamically determined have been moved to a separate file.