### PR TITLE
Move the release tox environment to the main branch

### DIFF
--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -25,7 +25,7 @@ jobs:
           # branches
           git fetch origin
           git restore --source origin/${{ github.event.repository.default_branch }} tools/
-          tox -e release -- -o snap/snapcraft.yaml -r ${{ inputs.openstack-release }}
+          tox -c tools -e release -- -o snap/snapcraft.yaml -r ${{ inputs.openstack-release }}
           git checkout -- tools/
           git diff --exit-code snap/snapcraft.yaml \
           && echo "create_pr=0" >> $GITHUB_OUTPUT \

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,0 +1,12 @@
+# This tox.ini is specific to the update_snapcraft.py script, which is always
+# run from the main branch
+[testenv:release]
+deps =
+    feedparser
+    pygit2
+    pyyaml
+    semver
+    packaging
+changedir = {toxinidir}
+commands = python3 update_snapcraft.py {posargs}
+

--- a/tox.ini
+++ b/tox.ini
@@ -62,12 +62,3 @@ passenv =
 commands =
     pytest {toxinidir}/tests/functional {posargs:-v}
 
-[testenv:release]
-deps =
-    feedparser
-    pygit2
-    pyyaml
-    semver
-    packaging
-changedir = {toxinidir}
-commands = python3 tools/update_snapcraft.py {posargs}


### PR DESCRIPTION
This commit splits tox.ini between the more common environments (which will continue existing in all branches), and the release one, which is only going to be used to update tempest in snapcraft.yaml. The release environment can then be kept in the main branch only, along with the related update script.

Closes: #85