### PR TITLE
Update Tempest Release backports - Ussuri

### DIFF
--- a/requirements-manual.txt
+++ b/requirements-manual.txt
@@ -1,0 +1,3 @@
+# this is needed by the monasca plugin
+# see https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
+confluent-kafka==1.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -68,5 +68,6 @@ deps =
     pygit2
     pyyaml
     semver
+    packaging
 changedir = {toxinidir}
 commands = python3 tools/update_snapcraft.py {posargs}


### PR DESCRIPTION
Note the different confluent-kafka dependency version.

Partial: https://github.com/canonical/snap-tempest/issues/85