### PR TITLE
Use the auto-generated token.

### DIFF
--- a/.github/workflows/update-snapcraft.yaml
+++ b/.github/workflows/update-snapcraft.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.update_snapcraft.outputs.create_pr == 1 }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}  # update this token in repo secret when no longer valid 
+          GITHUB_TOKEN: ${{ github.token }}  # Use the auto-generated action token
         run: |
           git config user.name "Github Action Bot"
           git config user.email "<>"


### PR DESCRIPTION
Instead of manually managing personal access tokens as repo secrets, use the auto-generated one. See
https://docs.github.com/en/actions/security-guides/automatic-token-authentication