### PR TITLE
Re-add comments re confluent-kafka version (bobcat backport)

### DIFF
--- a/requirements-manual.txt
+++ b/requirements-manual.txt
@@ -1,3 +1,6 @@
-# this is needed by the monasca plugin
+# confluent-kafka is needed by the monasca plugin
 # see https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
+# confluent-kafka versions are compatible with the same librdkafka versions,
+# so the version must match that of the base ubuntu release, which is currently jammy.
+# jammy repositories have librdkafka==1.8
 confluent-kafka==1.8.2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,11 @@ parts:
     source-type: git
     source-tag: 37.0.0
     python-packages:
+      # confluent-kafka is needed by the monasca plugin
+      # see https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
+      # confluent-kafka versions are compatible with the same librdkafka versions,
+      # so the version must match that of the base ubuntu release, which is currently jammy.
+      # jammy repositories have librdkafka==1.8
     - confluent-kafka==1.8.2
     - git+https://opendev.org/openstack/barbican-tempest-plugin.git@3.1.0
     - git+https://opendev.org/openstack/blazar-tempest-plugin.git@0.11.0


### PR DESCRIPTION
These comments are important for context,
and will help in future when version updates are required,
and for rationale of rejecting auto dependabot updates, etc.

(cherry picked from commit 675fb075e90e7c7439d5cabf28199ab3c62a3cb7)
