### PR TITLE
Rework and preserve comments in snapcraft.yaml during dependency updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,13 +42,10 @@ parts:
     plugin: python
     source: https://opendev.org/openstack/tempest.git
     source-type: git
+    # 'source-tag' and 'python-packages' are automatically generated and managed by
+    # tools/update_snapcraft.py, and therefore, should not be manually modified.
     source-tag: 34.1.0
     python-packages:
-      # confluent-kafka is needed by the monasca plugin
-      # see https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
-      # confluent-kafka versions are compatible with the same librdkafka versions,
-      # so the version must match that of the base ubuntu release, which is currently jammy.
-      # jammy repositories have librdkafka==1.8
     - confluent-kafka==1.8.2
     - git+https://opendev.org/openstack/barbican-tempest-plugin.git@2.0.0
     - git+https://opendev.org/openstack/blazar-tempest-plugin.git@0.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -69,5 +69,6 @@ deps =
     pyyaml
     semver
     packaging
+    ruamel.yaml
 changedir = {toxinidir}
 commands = python3 tools/update_snapcraft.py {posargs}


### PR DESCRIPTION
The comment in `snap/snapcraft.yaml` will be overwritten by `tools/update_snapcraft.py` when refreshing dependency versions (e.g. https://github.com/canonical/snap-tempest/pull/121/files) because pyYAML doesn't support comments. Use `ruamel.yaml` instead with its round trip mode to solve the problem.

Also replace the previous comment (since it's also in `requirements-manual.txt`) with a new one which informs user that
some dependencies are automatically generated. This also gives user a hint about where to check when they are unsure why a package like `confluent-kafka` is added as a dependency. 

Once merged, the changes will be backported to the release branches.