### PR TITLE
Xena backport

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 
 # These owners will be the default owners for everything in the repo. Unless a
-# later match takes precedence, @canonical/bootstack will be requested for
+# later match takes precedence, @canonical/soleng will be requested for
 # review when someone opens a pull request.
-*       @canonical/bootstack-reviewers
+*       @canonical/soleng-reviewers

--- a/snap/local/tempest-wrapper
+++ b/snap/local/tempest-wrapper
@@ -1,8 +1,8 @@
 #!/bin/bash
-original_args="$*"
-tests_dir=$TESTS
 
-final_args=$(echo $original_args | sed "s|@BUILTIN_TESTLISTS|$tests_dir|g")
+args=()
+for arg in "$@"; do
+    args+=("$(printf "%s" "$arg" | sed "s|@BUILTIN_TESTLISTS|$TESTS|g")")
+done
 
-IFS=' ' read -a arr <<< "$final_args"
-exec ${arr[@]}
+exec "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,8 @@ parts:
     plugin: python
     source: https://opendev.org/openstack/tempest.git
     source-type: git
+    # 'source-tag' and 'python-packages' are automatically generated and managed by
+    # tools/update_snapcraft.py, and therefore, should not be manually modified.
     source-tag: xena-last
     python-packages:
     - confluent-kafka==1.8.2


### PR DESCRIPTION
Backport changes in #72, #117, and #122 (partially because we are only using `./tools/update_snapcraft.py` from the main branch) to xena stable branch