### PR TITLE
Don't bundle uncommon plugins until we are sure they work well.

### DIFF
--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -2,21 +2,21 @@
 # tests even when the corresponding endpoint isn't available (see for example
 # https://storyboard.openstack.org/#!/story/2011097)
 # They will be excluded from the snap for now
-blazar
-cloudkitty
-cyborg
-ec2api
-freezer
-kuryr
-mistral
-monasca
-murano
-oswin
-sahara
-senlin
-trove
-venus
-vitrage
-watcher
-zaqar
-zed
+blazar-tempest-plugin
+cloudkitty-tempest-plugin
+cyborg-tempest-plugin
+ec2api-tempest-plugin
+freezer-tempest-plugin
+kuryr-tempest-plugin
+mistral-tempest-plugin
+monasca-tempest-plugin
+murano-tempest-plugin
+oswin-tempest-plugin
+sahara-tempest-plugin
+senlin-tempest-plugin
+trove-tempest-plugin
+venus-tempest-plugin
+vitrage-tempest-plugin
+watcher-tempest-plugin
+zaqar-tempest-plugin
+zun-tempest-plugin

--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -12,7 +12,7 @@ mistral-tempest-plugin
 monasca-tempest-plugin
 murano-tempest-plugin
 oswin-tempest-plugin
-sahara-tempest-plugin
+sahara-tests
 senlin-tempest-plugin
 trove-tempest-plugin
 venus-tempest-plugin

--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -1,0 +1,22 @@
+# These less-common plugins have proved to be problematic by attempting to run
+# tests even when the corresponding endpoint isn't available (see for example
+# https://storyboard.openstack.org/#!/story/2011097)
+# They will be excluded from the snap for now
+blazar
+cloudkitty
+cyborg
+ec2api
+freezer
+kuryr
+mistral
+monasca
+murano
+oswin
+sahara
+senlin
+trove
+venus
+vitrage
+watcher
+zaqar
+zed

--- a/tools/update_snapcraft.py
+++ b/tools/update_snapcraft.py
@@ -123,11 +123,13 @@ def get_latest_plugin_requirements(release, excluded_plugins):
 
     for file_path in (RELEASES_REPO_PATH / "deliverables" / release).iterdir():
         metadata = yaml.load(file_path.read_text())
-        if metadata["type"] == "tempest-plugin" and metadata["team"] not in excluded_plugins:
+        if metadata["type"] == "tempest-plugin":
             project = list(metadata["repository-settings"])[0]
-            feed_url = OPENSTACK_TAGS_RSS_FEED_FMT.format(project=project)
-            tag = get_latest_tag_from_feed(feed_url, release)
-            result.append(OPENSTACK_REPO_URL_FMT.format(project=project, ref=tag))
+            plugin_name = project.rsplit('/').pop()
+            if plugin_name not in excluded_plugins:
+                feed_url = OPENSTACK_TAGS_RSS_FEED_FMT.format(project=project)
+                tag = get_latest_tag_from_feed(feed_url, release)
+                result.append(OPENSTACK_REPO_URL_FMT.format(project=project, ref=tag))
 
     return sorted(result)
 

--- a/tools/update_snapcraft.py
+++ b/tools/update_snapcraft.py
@@ -38,7 +38,7 @@ EXCLUDED_PLUGINS_PATH = Path(__file__).parents[1] / Path("excluded-plugins.txt")
 def parse_excluded_plugins(path):
     """Parse an excluded-plugins.txt path.
 
-    Strip comments and whitespcea
+    Strip comments and whitespace
     """
     excluded_plugins = set()
 

--- a/tools/update_snapcraft.py
+++ b/tools/update_snapcraft.py
@@ -35,6 +35,25 @@ MANUAL_REQUIREMENTS = Path(__file__).parents[1] / Path("requirements-manual.txt"
 EXCLUDED_PLUGINS_PATH = Path(__file__).parents[1] / Path("excluded-plugins.txt")
 
 
+def parse_excluded_plugins(path):
+    """Parse an excluded-plugins.txt path.
+
+    Strip comments and whitespcea
+    """
+    excluded_plugins = set()
+
+    if path.exists():
+        with open(path, encoding="utf-8") as excl_file:
+            for line in excl_file:
+                plugin = line.split("#", maxsplit=1)[0].strip()
+                excluded_plugins.add(plugin)
+
+    # Lines starting with a comment would have been added here as empty strings
+    excluded_plugins.discard("")
+
+    return excluded_plugins
+
+
 def parse_manual_requirements(path):
     """Parse a requirements.txt path.
 
@@ -62,13 +81,6 @@ def parse_args():
     parser.add_argument("-r", "--release", required=True, type=str, help="OpenStack release")
     parser.add_argument(
         "-o", "--output", default="/dev/stdout", type=str, help="Output file. Defaults to stdout"
-    )
-    parser.add_argument(
-        "-e",
-        "--exclude-file",
-        default=EXCLUDED_PLUGINS_PATH,
-        type=str,
-        help="Path to a list of excluded plugins file.",
     )
     parser.add_argument(
         "--reuse",
@@ -167,7 +179,7 @@ def clone_releases_repository(reuse):
 def main(args):
     """Entry point to the application."""
     clone_releases_repository(args.reuse)
-    excluded_plugins = EXCLUDED_PLUGINS_PATH.read_text().split("\n")
+    excluded_plugins = parse_excluded_plugins(EXCLUDED_PLUGINS_PATH)
     snapcraft_yaml_path = Path(__file__).parent.parent / "snap" / "snapcraft.yaml"
     snapcraft_yaml = yaml.load(snapcraft_yaml_path.read_text())
 

--- a/tools/update_snapcraft.py
+++ b/tools/update_snapcraft.py
@@ -125,7 +125,7 @@ def get_latest_plugin_requirements(release, excluded_plugins):
         metadata = yaml.load(file_path.read_text())
         if metadata["type"] == "tempest-plugin":
             project = list(metadata["repository-settings"])[0]
-            plugin_name = project.rsplit('/').pop()
+            plugin_name = project.rsplit("/").pop()
             if plugin_name not in excluded_plugins:
                 feed_url = OPENSTACK_TAGS_RSS_FEED_FMT.format(project=project)
                 tag = get_latest_tag_from_feed(feed_url, release)


### PR DESCRIPTION
This is a rather harsh workaround to some plugins not respecting their respective service being marked to be unavailable in tempest.conf