### PR TITLE
Remove congress tempest plugin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,6 @@ parts:
     python-packages:
     - git+https://opendev.org/openstack/barbican-tempest-plugin.git@ussuri-last
     - git+https://opendev.org/openstack/cinder-tempest-plugin.git@ussuri-last
-    - git+https://opendev.org/openstack/congress-tempest-plugin.git@1.0.0
     - git+https://opendev.org/openstack/designate-tempest-plugin.git@ussuri-last
     - git+https://opendev.org/openstack/heat-tempest-plugin.git@ussuri-last
     - git+https://opendev.org/openstack/ironic-tempest-plugin.git@ussuri-last


### PR DESCRIPTION
It currently crashes with an import error:

```
Failed to import test module: congress_tempest_plugin.tests.scenario.congress_datasources.test_aodh
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/snap/tempest/417/lib/python3.8/site-packages/congress_tempest_plugin/tests/scenario/congress_datasources/test_aodh.py", line 21, in <module>
    from congress_tempest_plugin.tests.scenario import manager_congress
  File "/snap/tempest/417/lib/python3.8/site-packages/congress_tempest_plugin/tests/scenario/manager_congress.py", line 29, in <module>
    from tempest import manager as tempestmanager
ImportError: cannot import name 'manager' from 'tempest' (/snap/tempest/417/lib/python3.8/site-packages/tempest/__init__.py)
```

According to https://opendev.org/openstack/congress-tempest-plugin , this plugin is no longer maintained.
This plugin is also not present on other releases of the tempest snap. So I think we can simply remove the plugin here.

Fixes: #186