### PR TITLE
Add watcher-tempest-plugin to stable/caracal

### DIFF
--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -1,0 +1,23 @@
+# These less-common plugins have proved to be problematic by attempting to run
+# tests even when the corresponding endpoint isn't available (see for example
+# https://storyboard.openstack.org/#!/story/2011097)
+# They will be excluded from the snap for now
+blazar-tempest-plugin
+cloudkitty-tempest-plugin
+congress-tempest-plugin
+cyborg-tempest-plugin
+ec2api-tempest-plugin
+freezer-tempest-plugin
+kuryr-tempest-plugin
+mistral-tempest-plugin
+monasca-tempest-plugin # if re-enabling, add the confluent-kafka package. See https://github.com/canonical/snap-tempest/pull/10#issuecomment-1682115758
+murano-tempest-plugin
+oswin-tempest-plugin
+sahara-tests
+senlin-tempest-plugin
+solum-tempest-plugin
+trove-tempest-plugin
+venus-tempest-plugin
+vitrage-tempest-plugin
+zaqar-tempest-plugin
+zun-tempest-plugin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,7 +60,9 @@ parts:
     - git+https://opendev.org/openstack/octavia-tempest-plugin.git@2.7.0
     - git+https://opendev.org/openstack/telemetry-tempest-plugin.git@2.2.0
     - git+https://opendev.org/openstack/watcher-tempest-plugin.git@3.1.0
-    - git+https://opendev.org/openinfra/python-tempestconf.git@3.5.0
+    # Point to specific commit to include watcher-tempest-plugin discoverability feature
+    # until the commit is released.
+    - git+https://opendev.org/openinfra/python-tempestconf.git@550e43bb45855359264c9e3dd9130ad6219c6f2d
     build-packages:
     - libssl-dev
     - libffi-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,7 @@ parts:
     - git+https://opendev.org/openstack/neutron-tempest-plugin.git@2.8.0
     - git+https://opendev.org/openstack/octavia-tempest-plugin.git@2.7.0
     - git+https://opendev.org/openstack/telemetry-tempest-plugin.git@2.2.0
+    - git+https://opendev.org/openstack/watcher-tempest-plugin.git@3.1.0
     - git+https://opendev.org/openinfra/python-tempestconf.git@3.5.0
     build-packages:
     - libssl-dev


### PR DESCRIPTION
Add watcher-tempest-plugin to stable/caracal

commit 550e43bb45 in python-temepstconf introduces
discovery of watcher service and updates tempest
config accordingly. The changes from v3.5.0 to the
above mentioned commit are few that should not break
anything on caracal. The changes introduced are case
sensitive for tempest config options and discovery
of watcher service. So install python-tempestconf to
the above commit in the snap to include watcher
discoverability feature.
    
Add excluded-plugins.txt from snap-tempest-automation
project and remove watcher-tempest-plugin from the list.

Depends-On:
- [x] https://review.opendev.org/c/openinfra/python-tempestconf/+/927893