### PR TITLE
chore: update to juju 3.6

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,6 @@ jobs:
     with:
       python-version-unit: "['3.8', '3.10']"
       python-version-func: "3.10"
-      juju-channel: "3.4/stable"
+      juju-channel: "3.6/stable"
       snapcraft: true
       commands: "['make functional']"


### PR DESCRIPTION
The PR updates the Juju version to `3.6` for the check CI job.